### PR TITLE
Dp current user posts

### DIFF
--- a/app_api/fixtures/authors.json
+++ b/app_api/fixtures/authors.json
@@ -16,32 +16,5 @@
             "bio": "ME!",
             "profile_image_url": ""
         }
-    },
-    {
-        "model": "app_api.author",
-        "pk": 3,
-        "fields": {
-            "author": 3,
-            "bio": "HEAR ME ROAR",
-            "profile_image_url": ""
-        }
-    },
-    {
-        "model": "app_api.author",
-        "pk": 4,
-        "fields": {
-            "author": 4,
-            "bio": "TEST",
-            "profile_image_url": ""
-        }
-    },
-    {
-        "model": "app_api.author",
-        "pk": 5,
-        "fields": {
-            "author": 5,
-            "bio": "no.",
-            "profile_image_url": ""
-        }
     }
 ]

--- a/app_api/fixtures/authors.json
+++ b/app_api/fixtures/authors.json
@@ -7,5 +7,41 @@
             "bio": "I am user!",
             "profile_image_url": ""
         }
+    },
+    {
+        "model": "app_api.author",
+        "pk": 2,
+        "fields": {
+            "author": 2,
+            "bio": "ME!",
+            "profile_image_url": ""
+        }
+    },
+    {
+        "model": "app_api.author",
+        "pk": 3,
+        "fields": {
+            "author": 3,
+            "bio": "HEAR ME ROAR",
+            "profile_image_url": ""
+        }
+    },
+    {
+        "model": "app_api.author",
+        "pk": 4,
+        "fields": {
+            "author": 4,
+            "bio": "TEST",
+            "profile_image_url": ""
+        }
+    },
+    {
+        "model": "app_api.author",
+        "pk": 5,
+        "fields": {
+            "author": 5,
+            "bio": "no.",
+            "profile_image_url": ""
+        }
     }
 ]

--- a/app_api/fixtures/posts.json
+++ b/app_api/fixtures/posts.json
@@ -17,7 +17,7 @@
 		"pk": 2,
 		"fields": {
 			"category": 1,
-			"author": 3,
+			"author": 2,
 			"title": "TRIUMPH",
 			"content": "Sorting by users for fun and profit",
 			"image_url": "https://www.macmillandictionary.com/external/slideshow/thumb/142242_thumb.jpg",

--- a/app_api/fixtures/posts.json
+++ b/app_api/fixtures/posts.json
@@ -11,5 +11,18 @@
 			"publication_date": "2022-04-04",
 			"post_tags": []
 		}
+	},
+	{
+		"model": "app_api.post",
+		"pk": 2,
+		"fields": {
+			"category": 1,
+			"author": 3,
+			"title": "TRIUMPH",
+			"content": "Sorting by users for fun and profit",
+			"image_url": "https://www.macmillandictionary.com/external/slideshow/thumb/142242_thumb.jpg",
+			"publication_date": "2022-05-04",
+			"post_tags": []
+		}
 	}
 ]

--- a/app_api/views/post.py
+++ b/app_api/views/post.py
@@ -30,6 +30,9 @@ class PostView(ViewSet):
         category = request.query_params.get('category', None)
         if category is not None:
             posts = posts.filter(category_id=category)
+        author = request.query_params.get('author', None)
+        if author is not None:
+            posts = posts.filter(author_id=author)
         serializer = PostSerializer(posts, many=True)
         return Response(serializer.data)
 


### PR DESCRIPTION
Updated client and server side to handle filtering by currently logged in user.

TO TEST:

On BOTH client and server side, please do the following. 
- [x] git fetch --all
- [x] git checkout DP-current-user-posts (same branch name for both sides)
- [x] verify you have at least 2 posts and 2 authors (users) in your DB. If you don't have two users, please register a new one via client. If you don't have two posts, run the posts fixture in terminal. (python3 manage.py loaddata posts)
- [x] run the server (python3 manage.py runserver)
- [x] run the client (npm start)
- [x] make sure you're logged in as either user 1 or user 2
- [x] select "My Posts"
- [ ]  verify that only the post(s) for the currently logged in user are displayed.
- [ ]  if successful, do a fun celebratory dance